### PR TITLE
Fix column order issue in findGivenNames function

### DIFF
--- a/R/findGivenNames.R
+++ b/R/findGivenNames.R
@@ -172,13 +172,14 @@ findGivenNames = function(x,
         if (NCOL(dfResponse) == 4) {
       
             dfResponse$country_id <- "all"
+            setcolorder(dfResponse, c("name", "gender", "probability", "count", "country_id"))
             dfNames = data.table::rbindlist(list(dfNames, dfResponse))
 
         }
         
         if (NCOL(dfResponse) == 5) {
       
-          
+            setcolorder(dfResponse, c("name", "gender", "probability", "count", "country_id"))
             dfNames = data.table::rbindlist(list(dfNames, dfResponse))
 
         }


### PR DESCRIPTION
- Adjusted the column order in the API response to match the expected data structure in findGivenNames.
- Added setcolorder() to ensure that the columns ("name", "gender", "probability", "count", "country_id") are properly aligned when merging API responses.
- This fixes an issue where column misalignment caused incorrect data merging, particularly when handling responses with different column orders.